### PR TITLE
Fix "str.replace is not a function"

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,9 +30,7 @@ export default function({
       copyFileSync(serverFile, `${out}/index.js`);
 
       builder.log.minor('Prerendering static pages');
-      await builder.writePrerendered({
-        dest: `${out}/prerendered`
-      });
+      await builder.writePrerendered(`${out}/prerendered`);
     }
   };
 


### PR DESCRIPTION
With `@sveltejs/kit` `1.0.0-next.301_svelte@3.46.4` it seems the `writePrerendered` API is a bit different, and takes in a direct string instead of an object.

This change fixes the build for me, and without it I get a crash with

```
> str.replace is not a function
    at posixify (file://...project-path.../node_modules/.pnpm/@sveltejs+kit@1.0.0-next.301_svelte@3.46.4/node_modules/@sveltejs/kit/dist/chunks/filesystem.js:108:13)
    at copy (file://...project-path.../node_modules/.pnpm/@sveltejs+kit@1.0.0-next.301_svelte@3.46.4/node_modules/@sveltejs/kit/dist/chunks/filesystem.js:33:17)
    at Object.writePrerendered (file://...project-path.../node_modules/.pnpm/@sveltejs+kit@1.0.0-next.301_svelte@3.46.4/node_modules/@sveltejs/kit/dist/chunks/index4.js:139:22)
    at adapt (file://...project-path.../node_modules/.pnpm/@mankins+svelte-adapter-express@0.1.0/node_modules/@mankins/svelte-adapter-express/index.js:33:21)
    at adapt (file://...project-path.../node_modules/.pnpm/@sveltejs+kit@1.0.0-next.301_svelte@3.46.4/node_modules/@sveltejs/kit/dist/chunks/index4.js:180:8)
    at file://...project-path.../node_modules/.pnpm/@sveltejs+kit@1.0.0-next.301_svelte@3.46.4/node_modules/@sveltejs/kit/dist/cli.js:935:11
```